### PR TITLE
update-init-template-revision

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pullquester",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Issues a pull request using configuration files in your current repo.",
   "author": "Jonathan Park <https://github.com/park9140>, Sam Noedel <sam.noedel@gmail.com>, James Trinklein <https://github.com/jtrinklein>",
   "scripts": {

--- a/pullrequest.tmpl
+++ b/pullrequest.tmpl
@@ -1,20 +1,32 @@
 <%= config.title %>
 
 <%= config.description %>
-<% if (config.reviewers && config.reviewers.length > 0) { %>### Code Review<% } %>
-<% _.forEach(config.reviewers, function(reviewer) { %> - [ ] <%- reviewer %>
+<% if (config.reviewers && config.reviewers.length > 0) { %>
+Code review:
+------------
+
+<% } %>
+<% _.forEach(config.reviewers, function(reviewer) { %> - <%- reviewer %>
 <% }); %>
 
-<% if (config.testers && config.testers.length > 0) { %>### Testing<% }%>
-<% _.forEach(config.testers, function(reviewer) { %> - [ ] <%- reviewer %>
+<% if (config.testers && config.testers.length > 0) { %>
+Testing:
+--------
+
+<% }%>
+<% _.forEach(config.testers, function(tester) { %> - [ ] <%- tester %>
 <% }); %>
 
-<% if (config.additionalRequirements && config.additionalRequirements.length > 0) { %>### Additional Requirements<% } %>
+<% if (config.additionalRequirements && config.additionalRequirements.length > 0) { %>
+Additional requirements:
+------------------------
+<% } %>
 <% _.forEach(config.additionalRequirements, function(additionalRequirement) { %> - [ ] <%- additionalRequirement %>
 <% }); %>
 
 <% if (config.issues && config.issues.length > 0) { %>
-### Related issues
-<% _.forEach(config.issues, function(issueNumber) { %> - [ ] #<%- issueNumber %>
-<% }); %>
+Related issues:
+---------------
 <% } %>
+<% _.forEach(config.issues, function(issue) { %> - <%- issue %>
+<% }); %>

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const CONFIG_REVISION = 3;
+const CONFIG_REVISION = 4;
 
 const inquirer = require('../inquirerWrapper'),
     _ = require('lodash'),


### PR DESCRIPTION
Update the default template (used on init) to be rev 4 template. Prevents needing to run 'pull update' immediately after init

Code review:
------------


 - @jaredreynolds